### PR TITLE
Fix compatibility with phantomjs 2.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,11 @@ With depict, charts based on living data can be rendered into flat images at reg
 
 ## Installation
 
-Depict requires PhantomJS 1.X, which can be installed on OS X via
-[Homebrew](http://brew.sh/). **Depict does not yet work with PhantomJS
-2.X**.
+Depict requires PhantomJS, which can be installed on OS X via
+[Homebrew](http://brew.sh/).
 
     brew update
-    brew install homebrew/versions/phantomjs192
-    brew link homebrew/versions/phantomjs192
+    brew install phantomjs
 
 Then, install depict from [npm](https://npmjs.org/package/depict). The global install is recommended for easy command-line access.
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "preferGlobal": true,
   "dependencies": {
     "optimist": "~0.6.0",
-    "phantom": "~0.7.2",
-    "phantomjs": "~1.9.12"
+    "phantom": "~1.0",
+    "phantomjs": "~2.1"
   }
 }

--- a/src/depict.js
+++ b/src/depict.js
@@ -4,6 +4,7 @@ var child_process = require('child_process');
 var fs = require('fs');
 var optimist = require('optimist');
 var phantom = require('phantom');
+var phantomOptions = { 'web-security': 'no' };
 
 var argv = optimist
 .usage('Usage: depict URL OUT_FILE [OPTIONS]')
@@ -97,7 +98,7 @@ function depict(url, out_file, selector, css_text) {
 
     console.log('\nRequesting', url);
 
-    phantom.create(createPage)
+    phantom.create({parameters: phantomOptions}, createPage)
 
     function createPage(_ph) {
         ph = _ph;


### PR DESCRIPTION
See https://github.com/amir20/phantomjs-node/issues/345

It looks like with phantomjs 2.x there is a problem communicating with it when `web-security` is enabled, which is the default.  For the purposes of this tool, that seems like not a major concern.  This could be removed in the future if the phantom node implementation changes.