### PR TITLE
Allow multiple css files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Then, install depict from [npm](https://npmjs.org/package/depict). The global in
     Options:
       -h, --help              Display help                                                               [default: false]
       -s, --selector          CSS selector                                                               [default: "body"]
-      -c, --css               CSS file to include in rendering                                           [default: false]
+      -c, --css               CSS file(s) to include in rendering                                        [default: false]
       -H, --hide-selector     Hide attributes of this selector before rendering.                         [default: false]
       -w, --browser-width     Specify the desired browser width.                                         [default: 1440]
       -d, --delay             Specify a delay time, in milliseconds.                                     [default: 1000]

--- a/README.md
+++ b/README.md
@@ -104,3 +104,11 @@ Hide multiple CSS selectors by using commas:
     us-wine.png \
     -H '.g-us-map-slider, .g-map-legend-click'
 
+Include multiple CSS files by using commas:
+
+    depict \
+    http://www.nytimes.com/interactive/2013/07/07/business/a-nation-of-wineries.html \
+    -s '.g-us-map-grid' \
+    us-wine.png \
+    -c 'hide-ui.css,touch-device.css'
+

--- a/src/depict.js
+++ b/src/depict.js
@@ -76,7 +76,9 @@ var out_file = argv._[1];
 var css_file = argv.c || argv.css;
 var css_text = '';
 if (css_file) {
-    css_text = fs.readFileSync(css_file, 'utf8');
+    css_file.split(',').forEach(function (css_path) {
+        css_text += fs.readFileSync(css_path.trim(), 'utf8')
+    })
 }
 
 var hide_selector = argv.H || argv["hide-selector"];


### PR DESCRIPTION
I had a use case where I wanted to use a base css file and then some specific ones for different scenarios. It's fairly simple but seems to work. No worries if it's too much for the lib.